### PR TITLE
Allow to pass CIVICRM_INSTALL_EXTRA_OPTS as free text over to cv 

### DIFF
--- a/build/civicrm/civicrm-docker-install
+++ b/build/civicrm/civicrm-docker-install
@@ -5,6 +5,7 @@ cv core:install \
   --db=mysql://${CIVICRM_DB_USER}:${CIVICRM_DB_PASSWORD}@${CIVICRM_DB_HOST}:${CIVICRM_DB_PORT}/${CIVICRM_DB_NAME} \
   --cms-base-url=${CIVICRM_UF_BASEURL} \
   -m extras.adminUser=${CIVICRM_ADMIN_USER} \
-  -m extras.adminPass=${CIVICRM_ADMIN_PASS}
+  -m extras.adminPass=${CIVICRM_ADMIN_PASS} \
+  ${CIVICRM_INSTALL_EXTRA_OPTS}
 
 # rm /var/www/html/private/civicrm.settings.php 


### PR DESCRIPTION
This should allow to add any extra option for cv via environmental variables. Useful for e.g. adding -f

Fixes #12