### PR TITLE
bake monolog into the container and add installer plugin to configure

### DIFF
--- a/build/civicrm/Dockerfile
+++ b/build/civicrm/Dockerfile
@@ -16,11 +16,20 @@ ARG CIVICRM_VERSION
 
 ARG CIVICRM_DOWNLOAD_URL="https://download.civicrm.org/civicrm-${CIVICRM_VERSION}-standalone.tar.gz"
 
+# TODO: make an official release
+ARG MONOLOG_DOWNLOAD_URL="https://lab.civicrm.org/ufundo/monolog/-/package_files/9/download"
+
 # Download the tarball
 
 RUN curl --fail --location ${CIVICRM_DOWNLOAD_URL} --output civicrm-standalone.tar.gz \
     && tar -xf civicrm-standalone.tar.gz \
     && rm civicrm-standalone.tar.gz
+
+# Download Monolog and move into core ext dir
+RUN curl --fail --location ${MONOLOG_DOWNLOAD_URL} --output civicrm-monolog.tar.gz \
+    && tar -xf civicrm-monolog.tar.gz \
+    && rm civicrm-monolog.tar.gz \
+    && mv monolog civicrm-standalone/core/ext/monolog
 
 FROM ${IMAGE_PREFIX}/civicrm-base:php${PHP_VERSION}
 
@@ -36,9 +45,9 @@ COPY --from=build  --chown=www-data:www-data /var/www/html/civicrm-standalone /v
 
 COPY civicrm-docker-entrypoint /usr/local/bin/
 
-# Add an installation script
-
+# Add installation script and plugins
 COPY civicrm-docker-install /usr/local/bin/
+COPY setup-plugins /var/www/html/core/setup/plugins/docker
 
 ENV CIVICRM_UF=Standalone
 

--- a/build/civicrm/setup-plugins/DockerMonolog.civi-setup.php
+++ b/build/civicrm/setup-plugins/DockerMonolog.civi-setup.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @file
+ *
+ * Install and configure Monolog to direct all logs to stdout
+ */
+
+if (!defined('CIVI_SETUP')) {
+  exit("Installation plugins must only be loaded by the installer.\n");
+}
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.init', function (\Civi\Setup\Event\InitEvent $e) {
+    $e->getModel()->extensions[] = 'monolog';
+  });
+
+\Civi\Setup::dispatcher()
+  ->addListener('civi.setup.installDatabase', function (\Civi\Setup\Event\InstallDatabaseEvent $e) {
+    if (!in_array('monolog', $e->getModel()->extensions)) {
+      // in case installing Monolog extension was overridden by user
+      return;
+    }
+
+    \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installDatabase'));
+
+    // disable monolog configs packaged in extension
+    \Civi\Api4\Monolog::update(FALSE)
+      ->addWhere('is_active', '=', TRUE)
+      ->addValue('is_active', FALSE)
+      ->execute();
+
+    // create new config to pass all to stdout
+    \Civi\Api4\Monolog::create(FALSE)
+      ->addValue('name', 'docker_std_out')
+      ->addValue('description', 'Direct all logs to stdout so they go to the Docker log feed')
+      ->addValue('minimum_severity', 'debug')
+      ->addValue('type', 'std_out')
+      ->addValue('channel', 'default')
+      ->addValue('is_active', TRUE)
+      ->addValue('is_default', TRUE)
+      ->addValue('is_final', TRUE)
+      ->addValue('weight', 0)
+      ->addValue('configuration_options', [
+        'cli_only' => FALSE,
+      ])
+      ->execute();
+
+  }, \Civi\Setup::PRIORITY_LATE);


### PR DESCRIPTION
- add a copy of the Monolog extension into to the civicrm container
- add an installer plugin to:
   a) enable Monolog on install;
   b) configure it to disable the standard monolog configs, and add a single config which directs all logs to stdout => so they show in the docker logs

The monolog release is a [slightly forked version ](https://lab.civicrm.org/ufundo/monolog/-/tree/stdouterrconfig?ref_type=heads). This is because the main branch currently restricts `stdout` logs to when you are using CLI - whereas we want web requests to send their logs through to stdout also. I also did a manual package release with the monolog composer dependencies.

Hopefully we can get that merged and then use an "official" release. But it should work as is.


