### PR TITLE
Set PHP memory limit

### DIFF
--- a/build/civicrm/Dockerfile
+++ b/build/civicrm/Dockerfile
@@ -24,9 +24,17 @@ RUN curl --fail --location ${CIVICRM_DOWNLOAD_URL} --output civicrm-standalone.t
 
 FROM ${IMAGE_PREFIX}/civicrm-base:php${PHP_VERSION}
 
-# Use the default production configuration
+# Use the default production PHP configuration
 
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php-cli.ini" 
+
+# Set PHP memory limit
+
+RUN echo 'memory_limit = ${PHP_MEMORY_LIMIT:-"256M"}\n'  >> $PHP_INI_DIR/php.ini
+
+RUN echo 'memory_limit = -1\n' >> $PHP_INI_DIR/php-cli.ini
 
 # Copy the downloaded tarball to /var/www/html as the www-data user
 
@@ -46,7 +54,7 @@ ENV CIVICRM_UF=Standalone
 
 RUN sed -i 's/80/${APACHE_PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
 
-ENV APACHE_PORT=80  
+ENV APACHE_PORT=80
 
 # Set ENTRYPOINT
 

--- a/build/wordpress/Dockerfile
+++ b/build/wordpress/Dockerfile
@@ -38,12 +38,13 @@ FROM ${IMAGE_PREFIX}/wordpress-base:php${PHP_VERSION}
 
 # Use the default production PHP configuration
 
-RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php-apache.ini" \
-    && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php-cli.ini" 
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php-cli.ini" 
 
 # Set PHP memory limit
 
-RUN echo 'memory_limit = ${PHP_MEMORY_LIMIT:-"256M"}\n'  >> $PHP_INI_DIR/php-apache2handler.ini
+RUN echo 'memory_limit = ${PHP_MEMORY_LIMIT:-"256M"}\n'  >> $PHP_INI_DIR/php.ini
 
 RUN echo 'memory_limit = -1\n' >> $PHP_INI_DIR/php-cli.ini
 


### PR DESCRIPTION
Fix the PHP configuration in the WordPress image.

Add the same configuration to the CiviCRM image - in particular the ability to set a memory limit.