### PR TITLE
add pdo_mysql for running tests

### DIFF
--- a/build/common-base/Dockerfile
+++ b/build/common-base/Dockerfile
@@ -56,6 +56,7 @@ RUN set -eux && \
     docker-php-ext-install gd && \
     docker-php-ext-install intl && \
     docker-php-ext-install mysqli && \
+    docker-php-ext-install pdo_mysql && \
     docker-php-ext-install zip
 
 # Download cv (https://github.com/civicrm/cv)


### PR DESCRIPTION
Add `pdo_mysql` php extension, which is required for:
- running headless tests
- some DrupalUtils stuff
- maybe league/csv?
- maybe IDS

See https://chat.civicrm.org/civicrm/pl/8giaxzymtjnt3qj6au693gqdra