### PR TITLE
Increment default to PHP 8.4

### DIFF
--- a/build.php
+++ b/build.php
@@ -46,7 +46,7 @@ $c['app']->main('[--dry-run] [--step] [--image-prefix=] [--image-filter=] [--php
   $wpVersion = unserialize(file_get_contents("https://api.wordpress.org/core/version-check/1.6/"))['offers'][0]['current'];
   $args['WORDPRESS_VERSION'] = $wpVersion;
 
-  $defaults = ['CIVICRM_VERSION' => $civiVersion, 'PHP_VERSION' => 'php8.3', 'WORDPRESS_VERSION' => $wpVersion];
+  $defaults = ['CIVICRM_VERSION' => $civiVersion, 'PHP_VERSION' => 'php8.4', 'WORDPRESS_VERSION' => $wpVersion];
   // The default image prefix is the official one.
   $imagePrefix ??= 'civicrm';
 


### PR DESCRIPTION
Closes #53 

CiviCRM 6.12 recommends PHP 8.4. We should increment the default to match this.

See https://github.com/civicrm/civicrm-core/pull/34520