### PR TITLE
Fix DSN construction in civicrm-docker-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ At a minimum, you should set the following environment variables:
 - `CIVICRM_DB_PASSWORD`
 - `CIVICRM_UF_BASEURL`
 
-Note that the `CIVICRM_DB_*` can be replaced with a single `CIVICRM_DSN` variable.
+`CIVICRM_DB_PORT` is optional and defaults to `3306`.
+
+Note that the `CIVICRM_DB_*` can be replaced with a single `CIVICRM_DSN` variable. A `CIVICRM_DSN` is used exactly as given, so you must percent-encode its credentials yourself. If you use the separate `CIVICRM_DB_*` variables instead, `civicrm-docker-install` percent-encodes the username, password and database name for you, and they may contain any character.
 
 **Experimental**: you can override the default apache port (in the container) by setting `APACHE_PORT`.
 

--- a/build/civicrm/civicrm-docker-install
+++ b/build/civicrm/civicrm-docker-install
@@ -1,10 +1,30 @@
 #!/usr/bin/env bash
-set -ex
+set -e
+
+# Percent-encode a value for use inside a DSN.
+#
+# Must be rawurlencode(), not urlencode(): CiviCRM decodes DSN credentials with
+# rawurldecode(), which reads a '+' as a literal '+' rather than as a space.
+dsn_encode() {
+  CIVICRM_DSN_ENCODE_IN="${1-}" php -r 'echo rawurlencode(getenv("CIVICRM_DSN_ENCODE_IN"));'
+}
+
+if [ -n "${CIVICRM_DSN-}" ]; then
+  # Taken verbatim; the caller is responsible for encoding its credentials.
+  db_dsn="${CIVICRM_DSN}"
+else
+  : "${CIVICRM_DB_HOST:?is not set (set it, or supply a complete CIVICRM_DSN)}"
+  : "${CIVICRM_DB_NAME:?is not set (set it, or supply a complete CIVICRM_DSN)}"
+  : "${CIVICRM_DB_USER:?is not set (set it, or supply a complete CIVICRM_DSN)}"
+  db_dsn="mysql://$(dsn_encode "${CIVICRM_DB_USER}"):$(dsn_encode "${CIVICRM_DB_PASSWORD-}")@${CIVICRM_DB_HOST}:${CIVICRM_DB_PORT:-3306}/$(dsn_encode "${CIVICRM_DB_NAME}")"
+fi
+
+: "${CIVICRM_UF_BASEURL:?is not set}"
 
 cv core:install \
-  --db=mysql://${CIVICRM_DB_USER}:${CIVICRM_DB_PASSWORD}@${CIVICRM_DB_HOST}:${CIVICRM_DB_PORT}/${CIVICRM_DB_NAME} \
-  --url=${CIVICRM_UF_BASEURL} \
-  -m extras.adminUser=${CIVICRM_ADMIN_USER} \
-  -m extras.adminPass=${CIVICRM_ADMIN_PASS}
+  --db="${db_dsn}" \
+  --url="${CIVICRM_UF_BASEURL}" \
+  -m extras.adminUser="${CIVICRM_ADMIN_USER}" \
+  -m extras.adminPass="${CIVICRM_ADMIN_PASS}"
 
-# rm /var/www/html/private/civicrm.settings.php 
+# rm /var/www/html/private/civicrm.settings.php


### PR DESCRIPTION
Overview
----------------------------------------

`civicrm-docker-install` builds the `--db` DSN by plain string interpolation, so an install fails outright if the database password contains a character that is reserved in a URL. It also ignores `CIVICRM_DSN`, which the README documents as a supported alternative, and echoes both passwords into the container logs.

Before
----------------------------------------

With a `#` in `MYSQL_PASSWORD`:

$ docker compose exec -u www-data app civicrm-docker-install
Found code for civicrm-core in /var/www/html/core
Found code for civicrm-setup in /var/www/html/core/setup

In DbUtil.php line 13:

  array_map(): Argument #2 ($array) must be of type array, false given

Setting `CIVICRM_DSN` instead of the parts fails the same way, because the script never reads it and builds `mysql://:@:/`.

And because of `set -ex`, every install logs:

- cv core:install --db=mysql://civicrm:s3cr3t@db:3306/civicrm --url=http://localhost:8760 -m extras.adminUser=admin -m extras.adminPass=hunter2

After
----------------------------------------

All of those work. A missing variable now names itself instead of producing a malformed DSN:

civicrm-docker-install: line 16: CIVICRM_DB_HOST: is not set (set it, or supply a complete CIVICRM_DSN)

Technical Details
----------------------------------------

- **Percent-encode the credentials.** Uses `rawurlencode()`, not `urlencode()`, because CiviCRM decodes DSN credentials with `rawurldecode()`, which would take a `+` literally rather than as a space. Encoding is done via the `php` already present in the image, passing the value through the environment rather than `argv` so it does not appear in `ps`.
- **Honour `CIVICRM_DSN`.** `README.md` states the `CIVICRM_DB_*` variables can be replaced with a single `CIVICRM_DSN`, and that holds at runtime because core reads it as an env-loadable boot setting — but the install script only ever concatenated the separate parts.
- **Fail fast** naming the missing variable, and default `CIVICRM_DB_PORT` to `3306`.
- **Quote the expansions**, so a value containing whitespace cannot re-split the arguments.
- **Drop `set -x`** (keeping `-e`).

Comments
----------------------------------------

One case is deliberately not fixed here, because it is not this script's bug: a database password containing a space still breaks *after* installation, because civicrm-setup writes the settings file with `urlencode()` while PEAR reads it back with `rawurldecode()`. I have a PR open against civicrm-core for that; encoding correctly here is necessary but not sufficient until it lands.

Also left alone: `CIVICRM_ADMIN_USER` and `CIVICRM_ADMIN_PASS` are still unguarded. I did not want to add a check without first confirming how `cv core:install` treats an empty `extras.adminPass`.